### PR TITLE
Correct connection strings

### DIFF
--- a/src/Surging.Core/Surging.Core.System/MongoProvider/Repositories/MongoRepository.cs
+++ b/src/Surging.Core/Surging.Core.System/MongoProvider/Repositories/MongoRepository.cs
@@ -21,7 +21,7 @@ namespace Surging.Core.System.MongoProvider.Repositories
 
         public MongoRepository(string connectionString)
         {
-            _collection = Util.GetCollectionFromConnectionString<T>(Util.GetDefaultConnectionString());
+            _collection = Util.GetCollectionFromConnectionString<T>(connectionString);
         }
 
         public IMongoCollection<T> Collection

--- a/src/Surging.Core/Surging.Core.System/MongoProvider/Util.cs
+++ b/src/Surging.Core/Surging.Core.System/MongoProvider/Util.cs
@@ -26,7 +26,7 @@ namespace Surging.Core.System.MongoProvider
         public static IMongoCollection<T> GetCollectionFromConnectionString<T>(string connectionstring)
             where T : IEntity
         {
-            return GetDatabase(GetDefaultConnectionString()).GetCollection<T>(GetCollectionName<T>());
+            return GetDatabase(connectionstring).GetCollection<T>(GetCollectionName<T>());
         }
 
         private static string GetCollectionName<T>() where T : IEntity


### PR DESCRIPTION
Use parameter as connection string instead of the fixed configuration item.

原来的代码有问题。既然有参数，就应该使用参数。如果需要从配置文件获取，应该重载一个无参接口。